### PR TITLE
Enforce multiline method call indentation style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,3 +123,5 @@ Metrics/BlockLength:
 Naming:
   Enabled: false
 
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented_relative_to_receiver

--- a/example.rb
+++ b/example.rb
@@ -31,6 +31,13 @@ module Foo
           .joins(:badge)
           .group_by(:badge_count)
           .order_by(name: :asc)
+
+        _user =
+          User
+            .where(name: 'foobar')
+            .joins(:badge)
+            .group_by(:badge_count)
+            .order_by(name: :asc)
       end
 
       def variable_alignment


### PR DESCRIPTION
Somehow (might depend on a global Rubocop config on my local machine?), CodeClimate was complaining about the following code while locally it succeeded.

CodeClimate expected:

```ruby
_user =
  User
    .where(name: 'foobar')
    .joins(:badge)
    .group_by(:badge_count)
    .order_by(name: :asc)
```

to be formatted like:

```ruby
_user =
  User
  .where(name: 'foobar')
  .joins(:badge)
  .group_by(:badge_count)
  .order_by(name: :asc)
```

This added Rubocop rule enforces the former, just like we agreed on.