### PR TITLE
Disable UtilityFunction check for Rails helpers

### DIFF
--- a/config.reek
+++ b/config.reek
@@ -48,3 +48,8 @@ DuplicateMethodCall:
 UncommunicativeModuleName:
   accept:
     - V1
+
+# Allow Rails helpers that do not depend on instance state
+"app/helpers":
+  UtilityFunction:
+    enabled: false


### PR DESCRIPTION
By default, Reek [disallows instance methods that do not depend on instance state](https://github.com/troessner/reek/blob/master/docs/Utility-Function.md). That assumption is wrong for Rails helpers, so it should be disabled for `app/helpers`.