### PR TITLE
Correctly refer to linter config files

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -50,7 +50,7 @@ plugins:
   eslint:
     enabled: true
     config:
-      config: templates/linters/.eslintrc.json
+      config: .eslintrc.json
       extensions:
       - .es6
       - .js
@@ -64,11 +64,9 @@ plugins:
   rubocop:
     enabled: true
     config:
-      file: templates/linters/.rubocop.yml
+      file: .rubocop.yml
   reek:
     enabled: true
-    config:
-      config: templates/linters/config.reek
   scss-lint:
     enabled: true
   shellcheck:

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,1 @@
+templates/linters/.eslintrc.json

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+templates/linters/.rubocop.yml

--- a/config.reek
+++ b/config.reek
@@ -1,0 +1,1 @@
+templates/linters/config.reek


### PR DESCRIPTION
It seems Reek does not support having the config file stored in a subdirectory. This PR adds symlinks in the project root referring to the config files in the `templates/linters/` directory.