### PR TITLE
Set production log level to info

### DIFF
--- a/spec/templates/launch_base_default_template_spec.rb
+++ b/spec/templates/launch_base_default_template_spec.rb
@@ -109,4 +109,8 @@ describe 'App Generator' do
   it 'activates raising application errors for test environment' do
     expect_file_contents 'config/environments/test.rb', '  config.action_dispatch.show_exceptions = false'
   end
+
+  it 'sets the production log level to info' do
+    expect_file_contents 'config/environments/production.rb', 'config.log_level = :info'
+  end
 end

--- a/templates/launch_base_default_template.rb
+++ b/templates/launch_base_default_template.rb
@@ -62,6 +62,7 @@ template 'config/database.yml.erb', 'config/database.yml'
 
 uncomment_lines 'config/environments/development.rb', 'config.action_view.raise_on_missing_translations = true'
 uncomment_lines 'config/environments/test.rb', 'config.action_view.raise_on_missing_translations = true'
+gsub_file 'config/environments/production.rb', 'config.log_level = :debug', 'config.log_level = :info'
 
 after_bundle do
   run 'spring stop'


### PR DESCRIPTION
MS prefers to have a debug level of `info` for production environments (instead of `debug`).