### PR TITLE
Add commands to install/update linter configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /coverage/
 /node_modules
 .rspec_status
+/tmp/

--- a/lib/launch_base/cli.rb
+++ b/lib/launch_base/cli.rb
@@ -1,9 +1,11 @@
 require 'thor'
+require 'launch_base/lint_cli'
 
 module LaunchBase
   class CLI < Thor
     include Thor::Actions
     package_name 'launch_base'
+    register(LintCLI, 'lint', 'lint', 'Lint commands')
 
     desc 'update', "update #{LaunchBase}"
     long_desc <<-LONGDESC

--- a/lib/launch_base/cli.rb
+++ b/lib/launch_base/cli.rb
@@ -12,7 +12,7 @@ module LaunchBase
       `#{@package_name} update` triggers Bundler to update the #{LaunchBase} gem
     LONGDESC
     def update
-      run 'bundle update launch_base'
+      run 'bundle update launch_base --conservative'
     end
 
     def help

--- a/lib/launch_base/lint_cli.rb
+++ b/lib/launch_base/lint_cli.rb
@@ -16,6 +16,15 @@ module LaunchBase
       end
     end
 
+    desc 'update', 'update lint configuration files'
+    long_desc <<-LONGDESC
+      `#{@package_name} lint update` updates the gem and installs the lint configuration files
+    LONGDESC
+    def update
+      invoke CLI, 'update'
+      invoke :install
+    end
+
     private
 
     def gem_home

--- a/lib/launch_base/lint_cli.rb
+++ b/lib/launch_base/lint_cli.rb
@@ -16,9 +16,9 @@ module LaunchBase
       end
     end
 
-    desc 'update', 'update lint configuration files'
+    desc 'update', 'update gem and reinstall lint configuration files'
     long_desc <<-LONGDESC
-      `#{@package_name} lint update` updates the gem and installs the lint configuration files
+      `#{@package_name} lint update` updates the gem and reinstalls the lint configuration files
     LONGDESC
     def update
       invoke CLI, 'update'

--- a/lib/launch_base/lint_cli.rb
+++ b/lib/launch_base/lint_cli.rb
@@ -1,0 +1,25 @@
+require 'thor'
+
+module LaunchBase
+  class LintCLI < Thor
+    include Thor::Actions
+
+    desc 'install', 'install lint configuration files'
+    long_desc <<-LONGDESC
+      `#{@package_name} lint install` installs the lint configuration files into the current directory
+    LONGDESC
+    def install
+      ['.codeclimate.yml', '.eslintrc.json', '.mdlrc', '.rubocop.yml', 'config.reek'].each do |config_file_name|
+        create_file(config_file_name) do
+          gem_home.join('templates', config_file_name).read
+        end
+      end
+    end
+
+    private
+
+    def gem_home
+      Pathname.new(__dir__).join('..', '..')
+    end
+  end
+end

--- a/spec/launch_base/cli_spec.rb
+++ b/spec/launch_base/cli_spec.rb
@@ -1,7 +1,7 @@
 describe LaunchBase::CLI do
   describe 'update' do
     it 'runs `bundle update launch_base`' do
-      expect_any_instance_of(LaunchBase::CLI).to receive(:system).with('bundle update launch_base')
+      expect_any_instance_of(LaunchBase::CLI).to receive(:system).with('bundle update launch_base --conservative')
 
       invoke_command 'update'
     end
@@ -24,7 +24,7 @@ describe LaunchBase::CLI do
 
   describe 'lint update' do
     it 'updates the gem and installs the linter configuration files' do
-      expect_any_instance_of(LaunchBase::CLI).to receive(:system).with('bundle update launch_base')
+      expect_any_instance_of(LaunchBase::CLI).to receive(:system).with('bundle update launch_base --conservative')
 
       within_temp_test_directory do
         invoke_command 'lint', 'update'

--- a/spec/launch_base/cli_spec.rb
+++ b/spec/launch_base/cli_spec.rb
@@ -10,20 +10,30 @@ describe LaunchBase::CLI do
   describe 'lint install' do
     ['.codeclimate.yml', '.eslintrc.json', '.mdlrc', '.rubocop.yml', 'config.reek'].each do |configuration_file_name|
       it "installs the #{configuration_file_name} configuration file" do
-        test_directory = Pathname.new('tmp').join('launch_base', 'test_space')
-        FileUtils.rm_rf(test_directory)
-        FileUtils.mkdir_p(test_directory)
-
-        FileUtils.cd(test_directory) do
+        within_temp_test_directory do
           LaunchBase::CLI.start ['lint', 'install']
         end
 
-        templates_directory = Pathname.new(__dir__).join('..', '..', 'templates')
         source_file_path = templates_directory.join(configuration_file_name)
-        destination_path = test_directory.join(configuration_file_name)
+        destination_path = temp_test_directory.join(configuration_file_name)
 
         expect(destination_path.read).to eq source_file_path.read
       end
+    end
+  end
+
+  describe 'lint update' do
+    it 'updates the gem and installs the linter configuration files' do
+      expect_any_instance_of(LaunchBase::CLI).to receive(:system).with('bundle update launch_base')
+
+      within_temp_test_directory do
+        LaunchBase::CLI.start ['lint', 'update']
+      end
+
+      source_file_path = templates_directory.join('.codeclimate.yml')
+      destination_path = temp_test_directory.join('.codeclimate.yml')
+
+      expect(destination_path.read).to eq source_file_path.read
     end
   end
 

--- a/spec/launch_base/cli_spec.rb
+++ b/spec/launch_base/cli_spec.rb
@@ -7,6 +7,26 @@ describe LaunchBase::CLI do
     end
   end
 
+  describe 'lint install' do
+    ['.codeclimate.yml', '.eslintrc.json', '.mdlrc', '.rubocop.yml', 'config.reek'].each do |configuration_file_name|
+      it "installs the #{configuration_file_name} configuration file" do
+        test_directory = Pathname.new('tmp').join('launch_base', 'test_space')
+        FileUtils.rm_rf(test_directory)
+        FileUtils.mkdir_p(test_directory)
+
+        FileUtils.cd(test_directory) do
+          LaunchBase::CLI.start ['lint', 'install']
+        end
+
+        templates_directory = Pathname.new(__dir__).join('..', '..', 'templates')
+        source_file_path = templates_directory.join(configuration_file_name)
+        destination_path = test_directory.join(configuration_file_name)
+
+        expect(destination_path.read).to eq source_file_path.read
+      end
+    end
+  end
+
   describe 'help' do
     it 'includes the banner' do
       output = capture :stdout do

--- a/spec/launch_base/cli_spec.rb
+++ b/spec/launch_base/cli_spec.rb
@@ -3,7 +3,7 @@ describe LaunchBase::CLI do
     it 'runs `bundle update launch_base`' do
       expect_any_instance_of(LaunchBase::CLI).to receive(:system).with('bundle update launch_base')
 
-      LaunchBase::CLI.start ['update']
+      invoke_command 'update'
     end
   end
 
@@ -11,7 +11,7 @@ describe LaunchBase::CLI do
     ['.codeclimate.yml', '.eslintrc.json', '.mdlrc', '.rubocop.yml', 'config.reek'].each do |configuration_file_name|
       it "installs the #{configuration_file_name} configuration file" do
         within_temp_test_directory do
-          LaunchBase::CLI.start ['lint', 'install']
+          invoke_command 'lint', 'install'
         end
 
         source_file_path = templates_directory.join(configuration_file_name)
@@ -27,7 +27,7 @@ describe LaunchBase::CLI do
       expect_any_instance_of(LaunchBase::CLI).to receive(:system).with('bundle update launch_base')
 
       within_temp_test_directory do
-        LaunchBase::CLI.start ['lint', 'update']
+        invoke_command 'lint', 'update'
       end
 
       source_file_path = templates_directory.join('.codeclimate.yml')
@@ -39,9 +39,7 @@ describe LaunchBase::CLI do
 
   describe 'help' do
     it 'includes the banner' do
-      output = capture :stdout do
-        LaunchBase::CLI.start ['help']
-      end
+      output = invoke_command 'help'
 
       expected = /Kabisa LaunchBase/i
       expect(output).to match expected

--- a/spec/launch_base/cli_spec.rb
+++ b/spec/launch_base/cli_spec.rb
@@ -3,16 +3,14 @@ describe LaunchBase::CLI do
     it 'runs `bundle update launch_base`' do
       expect_any_instance_of(LaunchBase::CLI).to receive(:system).with('bundle update launch_base')
 
-      LaunchBase::CLI.new.invoke :update
+      LaunchBase::CLI.start ['update']
     end
   end
 
   describe 'help' do
     it 'includes the banner' do
-      cli = LaunchBase::CLI.new
-
       output = capture :stdout do
-        cli.invoke :help
+        LaunchBase::CLI.start ['help']
       end
 
       expected = /Kabisa LaunchBase/i

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,10 @@ RSpec.configure do |config|
 
   config.include LaunchBaseTestHelpers
 
+  if Class.new { include LaunchBaseTestHelpers }.new.dummy_app_path_not_set?
+    config.filter_run_excluding needs_dummy_app: true
+  end
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end

--- a/spec/support/launch_base_test_helpers.rb
+++ b/spec/support/launch_base_test_helpers.rb
@@ -43,6 +43,12 @@ module LaunchBaseTestHelpers
     Pathname.new(__dir__).join('..', '..', 'templates')
   end
 
+  def invoke_command(*args)
+    capture :stdout do
+      LaunchBase::CLI.start(args)
+    end
+  end
+
   private
 
   def dummy_app_path

--- a/spec/support/launch_base_test_helpers.rb
+++ b/spec/support/launch_base_test_helpers.rb
@@ -1,12 +1,15 @@
 module LaunchBaseTestHelpers
-  def project_path
-    environment_variable = 'DUMMY_APP_PATH'
-    dummy_app_path = ENV[environment_variable]
+  DUMMY_APP_PATH_ENV_VAR_NAME = 'DUMMY_APP_PATH'.freeze
 
-    raise "#{environment_variable} is missing" if (dummy_app_path || '').empty?
-    raise "#{environment_variable} #{dummy_app_path} does not exist" unless File.directory?(dummy_app_path)
+  def project_path
+    raise "#{DUMMY_APP_PATH_ENV_VAR_NAME} is missing" if dummy_app_path_not_set?
+    raise "#{DUMMY_APP_PATH_ENV_VAR_NAME} #{dummy_app_path} does not exist" unless File.directory?(dummy_app_path)
 
     dummy_app_path
+  end
+
+  def dummy_app_path_not_set?
+    (dummy_app_path || '').empty?
   end
 
   def expect_file_contents(file_path, expected_contents)
@@ -27,6 +30,10 @@ module LaunchBaseTestHelpers
   end
 
   private
+
+  def dummy_app_path
+    ENV[DUMMY_APP_PATH_ENV_VAR_NAME]
+  end
 
   def directory_existence(directory_path)
     File.directory?(project_file_path(directory_path))

--- a/spec/support/launch_base_test_helpers.rb
+++ b/spec/support/launch_base_test_helpers.rb
@@ -29,6 +29,20 @@ module LaunchBaseTestHelpers
     expect(file_existence(file_path)).to be true
   end
 
+  def within_temp_test_directory(&block)
+    FileUtils.rm_rf(temp_test_directory)
+    FileUtils.mkdir_p(temp_test_directory)
+    FileUtils.cd(temp_test_directory, &block)
+  end
+
+  def temp_test_directory
+    Pathname.new('tmp').join('launch_base', 'test_space')
+  end
+
+  def templates_directory
+    Pathname.new(__dir__).join('..', '..', 'templates')
+  end
+
   private
 
   def dummy_app_path

--- a/spec/templates/launch_base_default_template_spec.rb
+++ b/spec/templates/launch_base_default_template_spec.rb
@@ -1,4 +1,4 @@
-describe 'App Generator' do
+describe 'App Generator', :needs_dummy_app do
   it 'uses custom Gemfile' do
     expect_file_contents 'Gemfile', /gem 'rails', '5.2.0'/
   end

--- a/templates/config.reek
+++ b/templates/config.reek
@@ -53,3 +53,8 @@ UncommunicativeModuleName:
 "app/helpers":
   UtilityFunction:
     enabled: false
+
+# Allow spec helpers that do not depend on instance state
+"spec/support":
+  UtilityFunction:
+    enabled: false


### PR DESCRIPTION
This PR adds two commands to the CLI:

```
launch_base lint install         # install lint configuration files
launch_base lint update          # update gem and reinstall lint configuration files
```

Additional changes:

- the specs that need the generated dummy app are now excluded when `DUMMY_APP_PATH` is empty
- output from running CLI commands is captured by default to keep the RSpec output readable